### PR TITLE
Fast path for when there are no oldObjects in the collection

### DIFF
--- a/Classes/EPSChangeObserver.m
+++ b/Classes/EPSChangeObserver.m
@@ -36,11 +36,13 @@
         map:^RACTuple *(RACTuple *tuple) {
             RACTupleUnpack(NSArray *newObjects, NSDictionary *changeDictionary) = tuple;
             id oldObjects = changeDictionary[NSKeyValueChangeOldKey];
-            
+
             NSArray *oldObjectsArray;
-            if (oldObjects == [NSNull null]) oldObjectsArray = @[];
-            else oldObjectsArray = oldObjects;
-            
+			if (oldObjects == [NSNull null]) {
+				return RACTuplePack (@[], newObjects);
+			} else
+				oldObjectsArray = oldObjects;
+
             NSArray *rowsToRemove;
             
             rowsToRemove = [[[oldObjectsArray.rac_sequence


### PR DESCRIPTION
If there are no oldObjects we can assume all objects are being
inserted and skip all the contains checks, which can be quite slow.

This happens a lot when initially binding a large collection.
